### PR TITLE
Create README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Zotino 32-Channel DAC
+
+The Zotino is an ARTIQ-compatible 32-channel DAC. It is in the EEM (Eurocard Extension Module) form factor.
+
+## Design Files
+
+Design files (schematics, PCB layouts, BOMs) can be found at [Zotino/Releases](https://github.com/sinara-hw/Zotino/releases).
+
+This project is mostly edited offline, out of source control, and updated on each release.
+
+## Wiki
+
+More information can be found on the [wiki](https://github.com/sinara-hw/Zotino/wiki).


### PR DESCRIPTION
Clarify the location of schematics/BOMs/layouts, and point to wiki.

This README will show up when accessing the GitHub page for the Zotino project (see https://github.com/m-labs/artiq/blob/master/README.rst for an example). Implements/is a possible template for resolving the issue raised by @dtcallcock in https://github.com/sinara-hw/meta/issues/17#issuecomment-519980658